### PR TITLE
use correct container class and pass in application container

### DIFF
--- a/src/Payum/LaravelPackage/Payum.php
+++ b/src/Payum/LaravelPackage/Payum.php
@@ -1,7 +1,7 @@
 <?php
 namespace Payum\LaravelPackage;
 
-use Illuminate\Container;
+use Illuminate\Container\Container;
 
 class Payum extends SimpleRegistry
 {
@@ -41,4 +41,4 @@ class Payum extends SimpleRegistry
     {
         return is_object($id) ? $id : $this->container[$id];
     }
-} 
+}

--- a/src/Payum/LaravelPackage/PayumServiceProvider.php
+++ b/src/Payum/LaravelPackage/PayumServiceProvider.php
@@ -25,7 +25,7 @@ class PayumServiceProvider extends ServiceProvider
                 $app['config']['payum/payum-laravel-package::storages']
             );
 
-            $payum->setApplication($app);
+            $payum->setContainer($app);
             $payum->registerStorageExtensions();
 
             return $payum;


### PR DESCRIPTION
Couple of changes to make the ServiceProvider actually work...
- Illuminate\Foundation\Applicaton Extends Illuminate\Container\Container, not Illuminate\Container
- Payum::setApplication doesn't exist, but Payum::setContainer does
