### PR TITLE
let's follow laravel naming conventions so PayumFacade -> Payum

### DIFF
--- a/src/Payum/LaravelPackage/Facades/Payum.php
+++ b/src/Payum/LaravelPackage/Facades/Payum.php
@@ -1,9 +1,9 @@
 <?php
-namespace Payum\LaravelPackage;
+namespace Payum\LaravelPackage\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class PayumFacade extends Facade
+class Payum extends Facade
 {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
With this change, all we need in the `app.php` is:

```
'aliases' => array(
    // ....
    'Payum'           => 'Payum\LaravelPackage\Facades\Payum'
);
```

Then we can use it in our code as `Payum::method()` instead of `PayumFacade::method()`
