### PR TITLE
A namespace error on PayumController.php is generating FatalErrorExcepti...

### DIFF
--- a/src/Payum/LaravelPackage/Controller/PayumController.php
+++ b/src/Payum/LaravelPackage/Controller/PayumController.php
@@ -5,7 +5,7 @@ use Illuminate\Routing\Controllers\Controller;
 use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 
-abstract class PayumController extends Controller
+abstract class PayumController extends \Controller
 {
     /**
      * @return RegistryInterface


### PR DESCRIPTION
A namespace error on PayumController.php is generating FatalErrorException: Class 'Illuminate\Routing\Controllers\Controller' not found when calling capture url

i.e.: Calling http://localhost:8000/payment/capture/Yo9Ww5-IfcNlc-vcuX876DJhHcd5Tr9ZBQdKy5mrnYs
