### PR TITLE
Update to Laravel 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "illuminate/container": "~5.1",
-        "illuminate/routing": "~5.1",
-        "illuminate/support": "~5.1",
+        "illuminate/container": "~4.0|~5.1",
+        "illuminate/routing": "~4.0|~5.1",
+        "illuminate/support": "~4.0|~5.1",
         "payum/core": "1.0.*@dev"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "illuminate/container": "~4.0",
-        "illuminate/routing": "~4.0",
-        "illuminate/support": "~4.0",
+        "illuminate/container": "~5.1",
+        "illuminate/routing": "~5.1",
+        "illuminate/support": "~5.1",
         "payum/core": "1.0.*@dev"
     },
     "suggest": {

--- a/src/Payum/LaravelPackage/Controller/AuthorizeController.php
+++ b/src/Payum/LaravelPackage/Controller/AuthorizeController.php
@@ -18,8 +18,9 @@ class AuthorizeController extends PayumController
 
         $response = $this->convertReply($gateway->execute(new Authorize($token), true));
 
-        if($response)
+        if($response) {
             return $response;
+        }
 
         $this->getHttpRequestVerifier()->invalidate($token);
 

--- a/src/Payum/LaravelPackage/Controller/AuthorizeController.php
+++ b/src/Payum/LaravelPackage/Controller/AuthorizeController.php
@@ -16,7 +16,10 @@ class AuthorizeController extends PayumController
 
         $gateway = $this->getPayum()->getGateway($token->getGatewayName());
 
-        $gateway->execute(new Authorize($token));
+        $response = $this->convertReply($gateway->execute(new Authorize($token), true));
+
+        if($response)
+            return $response;
 
         $this->getHttpRequestVerifier()->invalidate($token);
 

--- a/src/Payum/LaravelPackage/Controller/CaptureController.php
+++ b/src/Payum/LaravelPackage/Controller/CaptureController.php
@@ -16,7 +16,11 @@ class CaptureController extends PayumController
 
         $gateway = $this->getPayum()->getGateway($token->getGatewayName());
 
-        $gateway->execute(new Capture($token));
+        
+        $response = $this->convertReply($gateway->execute(new Capture($token), true));
+
+        if($response)
+            return $response;
 
         $this->getHttpRequestVerifier()->invalidate($token);
 

--- a/src/Payum/LaravelPackage/Controller/CaptureController.php
+++ b/src/Payum/LaravelPackage/Controller/CaptureController.php
@@ -19,8 +19,9 @@ class CaptureController extends PayumController
         
         $response = $this->convertReply($gateway->execute(new Capture($token), true));
 
-        if($response)
+        if($response) {
             return $response;
+        }
 
         $this->getHttpRequestVerifier()->invalidate($token);
 

--- a/src/Payum/LaravelPackage/Controller/NotifyController.php
+++ b/src/Payum/LaravelPackage/Controller/NotifyController.php
@@ -26,8 +26,9 @@ class NotifyController extends PayumController
 
         $response = $this->convertReply($gateway->execute(new Notify($token), true));
 
-        if($response)
+        if($response) {
             return $response;
+        }
 
         return \Response::make(null, 204);
     }

--- a/src/Payum/LaravelPackage/Controller/NotifyController.php
+++ b/src/Payum/LaravelPackage/Controller/NotifyController.php
@@ -10,7 +10,10 @@ class NotifyController extends PayumController
     {
         $gateway = $this->getPayum()->getGateway($request->get('gateway_name'));
 
-        $gateway->execute(new Notify(null));
+        $response = $this->convertReply($gateway->execute(new Notify(null), true));
+
+        if($response)
+            return $response;
 
         return \Response::make(null, 204);
     }
@@ -21,7 +24,10 @@ class NotifyController extends PayumController
 
         $gateway = $this->getPayum()->getGateway($token->getGatewayName());
 
-        $gateway->execute(new Notify($token));
+        $response = $this->convertReply($gateway->execute(new Notify($token), true));
+
+        if($response)
+            return $response;
 
         return \Response::make(null, 204);
     }

--- a/src/Payum/LaravelPackage/Controller/PayumController.php
+++ b/src/Payum/LaravelPackage/Controller/PayumController.php
@@ -32,11 +32,13 @@ abstract class PayumController extends Controller
 
     protected function convertReply($reply)
     {
-        if(!$reply instanceof ReplyInterface)
+        if(!$reply instanceof ReplyInterface) {
             return;
+        }
 
-        if($this->shouldThrowExceptions())
+        if($this->shouldThrowExceptions()) {
             throw $reply;
+        }
 
         $response = null;
 

--- a/src/Payum/LaravelPackage/Controller/PayumController.php
+++ b/src/Payum/LaravelPackage/Controller/PayumController.php
@@ -30,10 +30,13 @@ abstract class PayumController extends Controller
         return \App::make('payum.security.http_request_verifier');
     }
 
-    public function convertReply($reply)
+    protected function convertReply($reply)
     {
         if(!$reply instanceof ReplyInterface)
             return;
+
+        if($this->shouldThrowExceptions())
+            throw $reply;
 
         $response = null;
 
@@ -54,5 +57,12 @@ abstract class PayumController extends Controller
             null,
             $reply
         );
+    }
+
+    protected function shouldThrowExceptions()
+    {
+        $l4Value = \Config::get('payum-laravel-package::settings.throwReplyExceptions');
+        $l5Value = \Config::get('payum-laravel-package.settings.throwReplyExceptions');
+        return $l4Value || $l5Value;
     }
 }

--- a/src/Payum/LaravelPackage/Controller/PayumController.php
+++ b/src/Payum/LaravelPackage/Controller/PayumController.php
@@ -1,11 +1,18 @@
 <?php
 namespace Payum\LaravelPackage\Controller;
 
-use Illuminate\Routing\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 
-abstract class PayumController extends \Controller
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Reply\ReplyInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class PayumController extends Controller
 {
     /**
      * @return RegistryInterface
@@ -21,5 +28,31 @@ abstract class PayumController extends \Controller
     protected function getHttpRequestVerifier()
     {
         return \App::make('payum.security.http_request_verifier');
+    }
+
+    public function convertReply($reply)
+    {
+        if(!$reply instanceof ReplyInterface)
+            return;
+
+        $response = null;
+
+        if ($reply instanceof SymfonyHttpResponse) {
+            $response = $reply->getResponse();
+        } elseif ($reply instanceof HttpRedirect) {
+            $response = new RedirectResponse($reply->getUrl());
+        } elseif ($reply instanceof HttpResponse) {
+            $response = new Response($reply->getContent());
+        } 
+        if ($response) {
+            return $response;
+        }
+
+        $ro = new \ReflectionObject($reply);
+        throw new LogicException(
+            sprintf('Cannot convert reply %s to Laravel response.', $ro->getShortName()),
+            null,
+            $reply
+        );
     }
 }

--- a/src/Payum/LaravelPackage/Controller/RefundController.php
+++ b/src/Payum/LaravelPackage/Controller/RefundController.php
@@ -18,8 +18,9 @@ class RefundController extends PayumController
 
         $response = $this->convertReply($gateway->execute(new Refund($token), true));
 
-        if($response)
+        if($response) {
             return $response;
+        }
 
         $this->getHttpRequestVerifier()->invalidate($token);
 

--- a/src/Payum/LaravelPackage/Controller/RefundController.php
+++ b/src/Payum/LaravelPackage/Controller/RefundController.php
@@ -16,7 +16,10 @@ class RefundController extends PayumController
 
         $gateway = $this->getPayum()->getGateway($token->getGatewayName());
 
-        $gateway->execute(new Refund($token));
+        $response = $this->convertReply($gateway->execute(new Refund($token), true));
+
+        if($response)
+            return $response;
 
         $this->getHttpRequestVerifier()->invalidate($token);
 

--- a/src/Payum/LaravelPackage/PayumServiceProvider.php
+++ b/src/Payum/LaravelPackage/PayumServiceProvider.php
@@ -2,92 +2,33 @@
 namespace Payum\LaravelPackage;
 
 use Illuminate\Support\ServiceProvider;
-use Payum\Core\Bridge\Symfony\Reply\HttpResponse as SymfonyHttpResponse;
-use Payum\Core\Bridge\Symfony\Security\HttpRequestVerifier;
-use Payum\Core\Exception\LogicException;
-use Payum\Core\Reply\HttpRedirect;
-use Payum\Core\Reply\HttpResponse;
-use Payum\Core\Reply\ReplyInterface;
-use Payum\Core\Security\GenericTokenFactory;
-use Payum\LaravelPackage\Registry\ContainerAwareRegistry;
-use Payum\LaravelPackage\Security\TokenFactory;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Foundation\Application;
 
 class PayumServiceProvider extends ServiceProvider
 {
+
+    /**
+     * Version Specific provider
+     */
+    protected $provider;
+
+    /**
+     * Create a new service provider instance.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     */
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+        $this->provider = $this->getProvider();
+    }
+
     /**
      * {@inheritDoc}
      */
     public function boot()
     {
-        $this->publishes([
-            __DIR__.'/../../config/config.php' => config_path('payum-laravel-package.php'),
-        ]);
-
-        $this->loadViewsFrom(__DIR__.'/../../views', 'payum/payum');
-
-        \Route::any('/payment/authorize/{payum_token}', array(
-            'as' => 'payum_authorize_do',
-            'uses' => 'Payum\LaravelPackage\Controller\AuthorizeController@doAction'
-        ));
-
-        \Route::any('/payment/capture/{payum_token}', array(
-            'as' => 'payum_capture_do',
-            'uses' => 'Payum\LaravelPackage\Controller\CaptureController@doAction'
-        ));
-
-        \Route::any('/payment/refund/{payum_token}', array(
-            'as' => 'payum_refund_do',
-            'uses' => 'Payum\LaravelPackage\Controller\RefundController@doAction'
-        ));
-
-        \Route::get('/payment/notify/{payum_token}', array(
-            'as' => 'payum_notify_do',
-            'uses' => 'Payum\LaravelPackage\Controller\NotifyController@doAction'
-        ));
-
-        \Route::get('/payment/notify/unsafe/{gateway_name}', array(
-            'as' => 'payum_notify_do_unsafe',
-            'uses' => 'Payum\LaravelPackage\Controller\NotifyController@doUnsafeAction'
-        ));
-
-        $this->app['payum'] = $this->app->share(function($app) {
-            //TODO add exceptions if invalid gateways and storages options set.
-
-            $payum = new ContainerAwareRegistry(
-                \Config::get('payum-laravel-package.gateways'),
-                \Config::get('payum-laravel-package.storages')
-            );
-
-            $payum->setContainer($app);
-
-            return $payum;
-        });
-
-        $this->app['payum.security.token_storage'] = $this->app->share(function($app) {
-            //TODO add exceptions if invalid gateways and storages options set.
-
-            $tokenStorage = \Config::get('payum-laravel-package.token_storage');
-
-            return is_object($tokenStorage) ? $tokenStorage : $app[$tokenStorage];
-        });
-
-        $this->app['payum.security.token_factory'] = $this->app->share(function($app) {
-            return new GenericTokenFactory(
-                new TokenFactory($app['payum.security.token_storage'], $app['payum']),
-                array(
-                    'capture' => 'payum_capture_do',
-                    'notify' => 'payum_notify_do',
-                    'authorize' => 'payum_authorize_do',
-                    'refund' => 'payum_refund_do',
-                )
-            );
-        });
-
-        $this->app['payum.security.http_request_verifier'] = $this->app->share(function($app) {
-            return new HttpRequestVerifier($app['payum.security.token_storage']);
-        });
+        $this->provider->boot();
     }
 
     /**
@@ -95,9 +36,7 @@ class PayumServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../../config/config.php', 'payum-laravel-package'
-        );
+        $this->provider->register();
     }
 
     /**
@@ -105,11 +44,20 @@ class PayumServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array(
-            'payum',
-            'payum.security.token_storage',
-            'payum.security.token_factory',
-            'payum.security.http_request_verifier',
-        );
+        return $this->provider->provides();
+    }
+
+    /**
+     *  Return ServiceProvider for current Laravel Version
+     * 
+     * @return \Illuminate\Support\ServiceProvider
+     */
+    protected function getProvider()
+    {
+        $provider = version_compare(Application::VERSION, '5.0', '<')
+            ? __NAMESPACE__.'\Providers\Laravel4'
+            : __NAMESPACE__.'\Providers\Laravel5';
+
+        return new $provider($this->app);
     }
 }

--- a/src/Payum/LaravelPackage/Providers/Laravel4.php
+++ b/src/Payum/LaravelPackage/Providers/Laravel4.php
@@ -25,8 +25,9 @@ class Laravel4 extends ServiceProvider
         \View::addNamespace('payum/payum', __DIR__.'/../../../views');
 
         // Throw reply exceptions unless the config is set not to for Laravel 4 only
-        if(\Config::get('payum-laravel-package::settings.throwReplyExceptions') == null)
+        if(\Config::get('payum-laravel-package::settings.throwReplyExceptions') == null) {
             \Config::set('payum-laravel-package::settings.throwReplyExceptions', true);
+        }
 
         $this->app->error(function(ReplyInterface $reply)
         {

--- a/src/Payum/LaravelPackage/Providers/Laravel4.php
+++ b/src/Payum/LaravelPackage/Providers/Laravel4.php
@@ -1,0 +1,137 @@
+<?php
+namespace Payum\LaravelPackage\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Payum\Core\Bridge\Symfony\Reply\HttpResponse as SymfonyHttpResponse;
+use Payum\Core\Bridge\Symfony\Security\HttpRequestVerifier;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Reply\ReplyInterface;
+use Payum\Core\Security\GenericTokenFactory;
+use Payum\LaravelPackage\Registry\ContainerAwareRegistry;
+use Payum\LaravelPackage\Security\TokenFactory;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class Laravel4 extends ServiceProvider
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function boot()
+    {
+        $this->package('payum/payum-laravel-package', 'payum-laravel-package', __DIR__.'/../../../');
+        \View::addNamespace('payum/payum', __DIR__.'/../../../views');
+
+        // Throw reply exceptions unless the config is set not to for Laravel 4 only
+        if(\Config::get('payum-laravel-package::settings.throwReplyExceptions') == null)
+            \Config::set('payum-laravel-package::settings.throwReplyExceptions', true);
+
+        $this->app->error(function(ReplyInterface $reply)
+        {
+            $response = null;
+
+            if ($reply instanceof SymfonyHttpResponse) {
+                $response = $reply->getResponse();
+            } elseif ($reply instanceof HttpResponse) {
+                $response = new Response($reply->getContent());
+            } elseif ($reply instanceof HttpRedirect) {
+                $response = new RedirectResponse($reply->getUrl());
+            }
+
+            if ($response) {
+                return $response;
+            }
+
+            $ro = new \ReflectionObject($reply);
+            throw new LogicException(
+                sprintf('Cannot convert reply %s to Laravel response.', $ro->getShortName()),
+                null,
+                $reply
+            );
+        });
+
+        \Route::any('/payment/authorize/{payum_token}', array(
+            'as' => 'payum_authorize_do',
+            'uses' => 'Payum\LaravelPackage\Controller\AuthorizeController@doAction'
+        ));
+
+        \Route::any('/payment/capture/{payum_token}', array(
+            'as' => 'payum_capture_do',
+            'uses' => 'Payum\LaravelPackage\Controller\CaptureController@doAction'
+        ));
+
+        \Route::any('/payment/refund/{payum_token}', array(
+            'as' => 'payum_refund_do',
+            'uses' => 'Payum\LaravelPackage\Controller\RefundController@doAction'
+        ));
+
+        \Route::get('/payment/notify/{payum_token}', array(
+            'as' => 'payum_notify_do',
+            'uses' => 'Payum\LaravelPackage\Controller\NotifyController@doAction'
+        ));
+
+        \Route::get('/payment/notify/unsafe/{gateway_name}', array(
+            'as' => 'payum_notify_do_unsafe',
+            'uses' => 'Payum\LaravelPackage\Controller\NotifyController@doUnsafeAction'
+        ));
+
+        $this->app['payum'] = $this->app->share(function($app) {
+            //TODO add exceptions if invalid gateways and storages options set.
+
+            $payum = new ContainerAwareRegistry(
+                \Config::get('payum-laravel-package::gateways'),
+                \Config::get('payum-laravel-package::storages')
+            );
+
+            $payum->setContainer($app);
+
+            return $payum;
+        });
+
+        $this->app['payum.security.token_storage'] = $this->app->share(function($app) {
+            //TODO add exceptions if invalid gateways and storages options set.
+
+            $tokenStorage = \Config::get('payum-laravel-package::token_storage');
+
+            return is_object($tokenStorage) ? $tokenStorage : $app[$tokenStorage];
+        });
+
+        $this->app['payum.security.token_factory'] = $this->app->share(function($app) {
+            return new GenericTokenFactory(
+                new TokenFactory($app['payum.security.token_storage'], $app['payum']),
+                array(
+                    'capture' => 'payum_capture_do',
+                    'notify' => 'payum_notify_do',
+                    'authorize' => 'payum_authorize_do',
+                    'refund' => 'payum_refund_do',
+                )
+            );
+        });
+
+        $this->app['payum.security.http_request_verifier'] = $this->app->share(function($app) {
+            return new HttpRequestVerifier($app['payum.security.token_storage']);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function register()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provides()
+    {
+        return array(
+            'payum',
+            'payum.security.token_storage',
+            'payum.security.token_factory',
+            'payum.security.http_request_verifier',
+        );
+    }
+}

--- a/src/Payum/LaravelPackage/Providers/Laravel5.php
+++ b/src/Payum/LaravelPackage/Providers/Laravel5.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Payum\LaravelPackage\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Payum\Core\Bridge\Symfony\Security\HttpRequestVerifier;
+use Payum\Core\Security\GenericTokenFactory;
+use Payum\LaravelPackage\Registry\ContainerAwareRegistry;
+use Payum\LaravelPackage\Security\TokenFactory;
+
+class Laravel5 extends ServiceProvider
+{
+
+    /**
+     * Version Specific provider
+     */
+    protected $provider;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../../../config/config.php' => config_path('payum-laravel-package.php'),
+        ]);
+
+        $this->loadViewsFrom(__DIR__.'/../../../views', 'payum/payum');
+
+        $this->defineRoutes();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../../../config/config.php', 'payum-laravel-package'
+        );
+
+        $this->app['payum'] = $this->app->share(function($app) {
+            //TODO add exceptions if invalid gateways and storages options set.
+
+            $payum = new ContainerAwareRegistry(
+                \Config::get('payum-laravel-package.gateways'),
+                \Config::get('payum-laravel-package.storages')
+            );
+
+            $payum->setContainer($app);
+
+            return $payum;
+        });
+
+        $this->app['payum.security.token_storage'] = $this->app->share(function($app) {
+            //TODO add exceptions if invalid gateways and storages options set.
+
+            $tokenStorage = \Config::get('payum-laravel-package.token_storage');
+
+            return is_object($tokenStorage) ? $tokenStorage : $app[$tokenStorage];
+        });
+
+        $this->app['payum.security.token_factory'] = $this->app->share(function($app) {
+            return new GenericTokenFactory(
+                new TokenFactory($app['payum.security.token_storage'], $app['payum']),
+                array(
+                    'capture' => 'payum_capture_do',
+                    'notify' => 'payum_notify_do',
+                    'authorize' => 'payum_authorize_do',
+                    'refund' => 'payum_refund_do',
+                )
+            );
+        });
+
+        $this->app['payum.security.http_request_verifier'] = $this->app->share(function($app) {
+            return new HttpRequestVerifier($app['payum.security.token_storage']);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provides()
+    {
+        return array(
+            'payum',
+            'payum.security.token_storage',
+            'payum.security.token_factory',
+            'payum.security.http_request_verifier',
+        );
+    }
+
+    /**
+     * Define all package routes with Laravel router
+     */
+    protected function defineRoutes(){
+        $route = $this->app->make('router');
+
+        $route->any('/payment/authorize/{payum_token}', array(
+            'as' => 'payum_authorize_do',
+            'uses' => 'Payum\LaravelPackage\Controller\AuthorizeController@doAction'
+        ));
+
+        $route->any('/payment/capture/{payum_token}', array(
+            'as' => 'payum_capture_do',
+            'uses' => 'Payum\LaravelPackage\Controller\CaptureController@doAction'
+        ));
+
+        $route->any('/payment/refund/{payum_token}', array(
+            'as' => 'payum_refund_do',
+            'uses' => 'Payum\LaravelPackage\Controller\RefundController@doAction'
+        ));
+
+        $route->get('/payment/notify/{payum_token}', array(
+            'as' => 'payum_notify_do',
+            'uses' => 'Payum\LaravelPackage\Controller\NotifyController@doAction'
+        ));
+
+        $route->get('/payment/notify/unsafe/{gateway_name}', array(
+            'as' => 'payum_notify_do_unsafe',
+            'uses' => 'Payum\LaravelPackage\Controller\NotifyController@doUnsafeAction'
+        ));
+    }
+}


### PR DESCRIPTION
Rebase #22 to master


As far as continuing support for Laravel 4 I can work on that. It would be a provider that delegates to the correct provider based on version.

For your concern about being able to change the response by making a new event listener on Laravel 5 you can do that with middleware just watching for the response types that are returned by the controller. If developers still want to catch exceptions instead of using middleware to convert the response there could be a config option to throw exceptions as before. What do you think?