### PR TITLE
Fix for Laravel 5.2

### DIFF
--- a/src/Payum/LaravelPackage/Model/Token.php
+++ b/src/Payum/LaravelPackage/Model/Token.php
@@ -16,6 +16,11 @@ class Token extends Model implements TokenInterface
      * @var string
      */
     protected $primaryKey = 'hash';
+    
+    /**
+     * @var bool
+     */
+    public $incrementing = false;
 
     /**
      * @var bool


### PR DESCRIPTION
Models with non-incrementing primary keys need to set incrementing to false to prevent the primary key being overwritten on write.