### PR TITLE
Fix doUnsafeAction of Notify Controller, could not resolve gateway_name parameter defined on route

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore
+/.editorconfig      export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.4]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,8 @@ jobs:
         laravel: [5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 5.1
+            testbench: 3.1.*
           - laravel: 5.8
             testbench: 3.8.*
           - laravel: 6.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        php: [7.1, 7.2, 7.3, 7.4]
+        laravel: [5.*]
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 5.*
+            testbench: 3.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.1, 7.2, 7.3, 7.4]
-        laravel: [5.*]
+        php: [7.1]
+        laravel: [5.1, 5.8]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 5.*
-            testbench: 3.*
+          - laravel: 5.1
+            testbench: 3.1.*
+          - laravel: 5.8
+            testbench: 3.8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -40,4 +42,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: composer test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.3, 7.4]
-        laravel: [5.8, 6.*, 7.*, 8.*]
+        laravel: [5,1, 5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 5.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.3, 7.4]
-        laravel: [5,1, 5.8, 6.*, 7.*, 8.*]
+        laravel: [5.1, 5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 5.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.1]
-        laravel: [5.1, 5.8]
+        laravel: [5.8]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 5.1
-            testbench: 3.1.*
           - laravel: 5.8
             testbench: 3.8.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         if: matrix.guzzle7-adapter
-        run: composer require "php-http/guzzle6-adapter:${{ matrix.guzzle7-adapter }}" --no-interaction --no-update
+        run: composer require "php-http/guzzle7-adapter:${{ matrix.guzzle7-adapter }}" --no-interaction --no-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,11 +6,11 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.3, 7.4]
-        laravel: [5.8, 6.*, 7.*]
+        laravel: [5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 5.8
@@ -19,6 +19,9 @@ jobs:
             testbench: 4.*
           - laravel: 7.*
             testbench: 5.*
+            guzzle7-adapter: ^0.1
+          - laravel: 8.*
+            testbench: 6.*
             guzzle7-adapter: ^0.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.4]
+        php: [7.3, 7.4]
         laravel: [5.8, 6.*, 7.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.3, 7.4]
-        laravel: [5.1, 5.8, 6.*, 7.*, 8.*]
+        laravel: [5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 5.1
-            testbench: 3.1.*
           - laravel: 5.8
             testbench: 3.8.*
           - laravel: 6.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,7 @@ jobs:
             testbench: 4.*
           - laravel: 7.*
             testbench: 5.*
+            guzzle7-adapter: ^0.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -37,6 +38,10 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        if: matrix.guzzle7-adapter
+        run: composer require "php-http/guzzle6-adapter:${{ matrix.guzzle7-adapter }}" --no-interaction --no-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.1]
+        php: [7.4]
         laravel: [5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.1]
-        laravel: [5.8]
+        laravel: [5.8, 6.*, 7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 5.8
             testbench: 3.8.*
+          - laravel: 6.*
+            testbench: 4.*
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 8.*
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.4]
-        laravel: [5.8, 6.*, 7.*, 8.*]
+        laravel: [5.8, 6.*, 7.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 5.8
@@ -19,8 +19,6 @@ jobs:
             testbench: 4.*
           - laravel: 7.*
             testbench: 5.*
-          - laravel: 8.*
-            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,4 +40,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: composer test
+        run: ./bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.idea
+.php_cs
+.php_cs.cache
+.phpunit.result.cache
+build
+composer.lock
+coverage
+docs
+phpunit.xml
+psalm.xml
+vendor
+package-skeleton-laravel
+.lando.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,8 @@
 .idea
-.php_cs
-.php_cs.cache
 .phpunit.result.cache
 build
 composer.lock
 coverage
 docs
 phpunit.xml
-psalm.xml
 vendor
-package-skeleton-laravel
-.lando.yml

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
         "bin-dir": "bin"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.1.10|~3.8.6",
-        "phpunit/phpunit": "^7.5"
+        "orchestra/testbench": "~3.8.6|^4.8|^5.2|^6.0",
+        "phpunit/phpunit": "^7.5|^8.0|^9.0"
     },
     "scripts": {
       "test": "bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
         "bin-dir": "bin"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.8.6|^4.8|^5.2|^6.0",
-        "phpunit/phpunit": "^7.5|^8.0|^9.0"
+        "orchestra/testbench": "~3.1.10|~3.8.6|^4.8|^5.2|^6.0",
+        "phpunit/phpunit": "^4.0|^5.0|^7.5|^8.0|^9.0"
     },
     "scripts": {
       "test": "bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,11 @@
     "autoload": {
         "psr-0": { "Payum\\LaravelPackage": "src/" }
     },
+    "autoload-dev": {
+        "psr-4": {
+          "Payum\\LaravelPackage\\Tests\\": "tests"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
@@ -59,5 +64,12 @@
     },
     "config": {
         "bin-dir": "bin"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^3.8",
+        "phpunit/phpunit": "^7.5"
+    },
+    "scripts": {
+      "test": "bin/phpunit --colors=always"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.1.10|~3.8.6",
-        "phpunit/phpunit": "~4.0|~5.0|^7.5"
+        "phpunit/phpunit": "^7.5"
     },
     "scripts": {
       "test": "bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
         "bin-dir": "bin"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.1.10|~3.8.6|^4.8|^5.2|^6.0",
-        "phpunit/phpunit": "^4.0|^5.0|^7.5|^8.0|^9.0"
+        "orchestra/testbench": "~3.8.6|^4.8|^5.2|^6.0",
+        "phpunit/phpunit": "^7.5|^8.0|^9.0"
     },
     "scripts": {
       "test": "bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
         "bin-dir": "bin"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.8",
-        "phpunit/phpunit": "^7.5"
+        "orchestra/testbench": "~3.1.10|~3.8.6",
+        "phpunit/phpunit": "~4.0|~5.0|^7.5"
     },
     "scripts": {
       "test": "bin/phpunit --colors=always"

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,6 @@
         "phpunit/phpunit": "~4.0|~5.0|^7.5"
     },
     "scripts": {
-      "test": "bin/phpunit --colors=always"
+      "test": "bin/phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         verbose="true"
 >
     <testsuites>
         <testsuite name="Payum LaravelBundle Tests">

--- a/src/Payum/LaravelPackage/Controller/NotifyController.php
+++ b/src/Payum/LaravelPackage/Controller/NotifyController.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class NotifyController extends PayumController
 {
-    public function doUnsafeAction(Request $request)
+    public function doUnsafeAction($gateway_name)
     {
-        $gateway = $this->getPayum()->getGateway($request->get('gateway_name'));
+        $gateway = $this->getPayum()->getGateway($gateway_name);
 
         $gateway->execute(new Notify(null));
 

--- a/tests/NotifyControllerTest.php
+++ b/tests/NotifyControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Payum\LaravelPackage\Tests;
+
+use Payum\Core\Exception\InvalidArgumentException;
+
+class NotifyControllerTest extends TestCase
+{
+    /** @test */
+    public function test_notify_unsafe_response_has_500_http_code_without_registered_gateway()
+    {
+        $gateway_name = 'not-exists';
+
+        $response = $this
+            ->call('GET', route('payum_notify_do_unsafe', ['gateway_name' => $gateway_name]))
+            ->assertStatus(500)
+        ;
+
+        $exception = $response->exception;
+        $expectedMessageException = sprintf('Gateway "%s" does not exist.', $gateway_name);
+        $this->assertEquals(get_class($exception), InvalidArgumentException::class);
+        $this->assertEquals($exception->getMessage(), $expectedMessageException);
+    }
+
+
+    /** @test */
+    public function test_notify_unsafe_payum_receive_right_gateway_name_parameter()
+    {
+        $gateway_name = 'not-exists';
+
+        $this
+            ->mock('payum', function($mock) use ($gateway_name){
+                $mock
+                    ->shouldReceive('getGateway')
+                    ->with($gateway_name)
+                    ->once();
+            });
+
+        $response = $this
+            ->call('GET', route('payum_notify_do_unsafe', ['gateway_name' => $gateway_name]))
+        ;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Payum\LaravelPackage\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Payum\Core\PayumBuilder;
+use Payum\LaravelPackage\PayumServiceProvider;
+
+class TestCase extends Orchestra
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var PayumBuilder $payumBuilder */
+        $payumBuilder = app('payum.builder');
+        $payumBuilder = $payumBuilder->addDefaultStorages();
+        $this->instance('payum.builder', $payumBuilder);
+        $this->swap('payum', $payumBuilder->getPayum());
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            PayumServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        /*
+        include_once __DIR__.'/../database/migrations/create_skeleton_table.php.stub';
+        (new \CreatePackageTable())->up();
+        */
+    }
+}


### PR DESCRIPTION
This PR fix an error with doUnsafeAction of Notify Controller.
This controller not resolve the gateway name parameter define in the related route, and cannot permit to use the notifications come from payment processor like Stripe.
It received the Request object as method parameter but not resolve the route parameter in the right way.

I've changed the firm of method, from `public function doUnsafeAction(Request $request)`  to `public function doUnsafeAction($gateway_name)` as relative route "payum_notify_do_unsafe" describe in service provider.

This PR is tested over PHP 7.3 and PHP 7.4, from Laravel 5.8 up to Laravel 8, using Github Actions.
It can be used on Laravel 5.1 as well, but is not actually tested from this PR. (I've test manually over a fresh L5.1 local installation)

To avoid a BC due to method firms change, i can be convert the fix try to resolve the `gateway_name` parameter through Request object.

